### PR TITLE
fixed the failure of verification against PACTs without provider_state

### DIFF
--- a/src/provider-state-manager.js
+++ b/src/provider-state-manager.js
@@ -2,14 +2,24 @@
 module.exports = function() {
 
     var setupProviderStateForInteraction = function(provider, interaction, providerStates) {
-        providerStates[interaction.provider_state](provider);
+        if('provider_state' in interaction
+            && typeof(providerStates[interaction.provider_state]) === 'function') {
+            providerStates[interaction.provider_state](provider);
+        }
+        else if('description' in interaction
+            && typeof(providerStates[interaction.description]) === 'function') {
+            providerStates[interaction.description](provider);
+        }
+        else {
+            throw new Error("missing provider state or description '" + JSON.stringify(interaction) + "'");
+        }
     };
 
     var verifyProviderStatesForInteractions = function(interactions, providerStates) {
         interactions.forEach(function(interaction) {
-            console.log('Interaction', interaction.provider_state)
-            if(typeof providerStates[interaction.provider_state] !== 'function') {
-                throw new Error("missing provider state '" + interaction.provider_state + "'");
+            console.log('Interaction', interaction.provider_state || interaction.description)
+            if(typeof providerStates[interaction.provider_state || interaction.description] !== 'function') {
+                throw new Error("missing provider state or description'" + JSON.stringify(interaction) + "'");
             }
         });
     };

--- a/src/verify.js
+++ b/src/verify.js
@@ -97,8 +97,8 @@ module.exports = function() {
 
         stateManager.setup(provider, interaction, providerStates);
 
-        console.log("  Given " + interaction.provider_state);
-        console.log("    " + interaction.description);
+        console.log("  Given " + (interaction.provider_state || 'there is no provider state in the interaction'));
+        console.log("    And " + (interaction.description || 'no description of the state in the interaction'));
         console.log("      with " + interaction.request.method.toUpperCase() + " " + interaction.request.path);
         console.log("        returns a response which");
 

--- a/test/integration/contract-no-description.json
+++ b/test/integration/contract-no-description.json
@@ -1,0 +1,29 @@
+{
+    "interactions": [
+        {
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application\/json"
+                },
+                "body": {
+                    "foo": "baz"
+                }
+            },
+            "request": {
+                "path": "\/resource\/1234",
+                "method": "GET",
+                "headers": {
+                    "Authenticated-User": "test"
+                }
+            },
+            "provider_state": "there is a resource at /1234"
+        }
+    ],
+    "provider": {
+        "name": "some resource API"
+    },
+    "consumer": {
+        "name": "some consumer"
+    }
+}

--- a/test/integration/contract-no-provider-state.json
+++ b/test/integration/contract-no-provider-state.json
@@ -1,0 +1,29 @@
+{
+    "interactions": [
+        {
+            "response": {
+                "status": 200,
+                "headers": {
+                    "Content-Type": "application\/json"
+                },
+                "body": {
+                    "foo": "baz"
+                }
+            },
+            "request": {
+                "path": "\/resource\/1234",
+                "method": "GET",
+                "headers": {
+                    "Authenticated-User": "test"
+                }
+            },
+            "description": "there is a resource at /1234"
+        }
+    ],
+    "provider": {
+        "name": "some resource API"
+    },
+    "consumer": {
+        "name": "some consumer"
+    }
+}

--- a/test/integration/test-with-fields-missing.js
+++ b/test/integration/test-with-fields-missing.js
@@ -1,0 +1,221 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+describe('Verify interactions with field missing: ', function(){
+
+    describe('restify - no provider state', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var app = require('./restify-app');
+            var contract = require('./contract-no-provider-state.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: app,
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+
+    describe('express - no provider state', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var app = require('./express-app');
+            var contract = require('./contract-no-provider-state.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: app,
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+
+    describe('Koa - no provider state', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var contract = require('./contract-no-provider-state.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: require('./koa-app'),
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact with koa', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+
+    describe('restify - no description', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var app = require('./restify-app');
+            var contract = require('./contract-no-description.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: app,
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+
+    describe('express - no description', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var app = require('./express-app');
+            var contract = require('./contract-no-description.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: app,
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+
+    describe('Koa - no description', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var contract = require('./contract-no-description.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: require('./koa-app'),
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact with koa', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+});
+

--- a/test/integration/test-with-null-body.js
+++ b/test/integration/test-with-null-body.js
@@ -1,0 +1,117 @@
+'use strict';
+
+var expect = require('chai').expect;
+
+describe('When loading a webserver with: ', function(){
+
+    describe('restify', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var app = require('./restify-app');
+            var contract = require('./contract.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: app,
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        console.log('Running state');
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+
+    describe('express', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var app = require('./express-app');
+            var contract = require('./contract.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: app,
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        console.log('Running state');
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+
+    describe('Koa', function(){
+
+        var errors;
+        var state = [];
+
+        beforeEach(function(done){
+
+            var pact = require('../..')();
+            var contract = require('./contract.json');
+
+            var providerPact = {
+                contract: contract,
+                provider: require('./koa-app'),
+                providerStates: {
+                    "there is a resource at /1234": function() {
+                        console.log('Running state');
+                        state.push(1);
+                    }
+                }
+            };
+
+            pact.verify(providerPact, function(e) {
+                errors = e;
+                done();
+            });
+        });
+
+        it('should report no errors and verify the pact with koa', function(){
+            expect(errors).to.eql([]);
+        });
+
+        it('should run the setup state function', function(){
+            expect(state).to.eql([1, 1]);
+        });
+    });
+});
+


### PR DESCRIPTION
- fixed some failures caused by different consumer pact with missing provider_state field in the interaction definitions and test cases, hence enhance the robustness a bit
- try not to break the rules defined in the specification and implementation guide line