### PR TITLE
Allow external server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 test/coverage/
 .idea
 .tern*
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently it is a bare-bones implementation that can verify a provider's respons
 Install
 -------
 
-    npm install pactjs --save-dev
+    npm install nodejs-pact-provider --save-dev
 
 Examples
 --------

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "deep-diff": "^0.3.2",
     "lodash": "^3.10.1",
     "q": "~1.0.1",
-    "request": "^2.40.0"
+    "request": "^2.40.0",
+    "url-join": "^1.1.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodejs-pact-provider",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Pact for Javascript",
   "dependencies": {
     "colors": "~0.6.2",

--- a/src/verify.js
+++ b/src/verify.js
@@ -2,7 +2,8 @@ var log = require('./log')('Pact verifier');
 var request = require('request');
 var _ = require('lodash');
 
-module.exports = function() {
+module.exports = function(providerUrl) {
+    providerUrl = providerUrl || "http://localhost:3000";
 
     // adds colours to strings
     require('colors');
@@ -109,7 +110,7 @@ module.exports = function() {
                     interaction.request.path + "?" + interaction.request.query;
 
             var options = {
-                url: "http://localhost:3000" + path,
+                url: pathproviderUrl + path,
                 headers: interaction.request.headers ? interaction.request.headers : {},
                 body: interaction.request.body,
                 method: interaction.request.method,

--- a/src/webserver-handling.js
+++ b/src/webserver-handling.js
@@ -3,7 +3,6 @@ var webserver;
 var urlRegex = /https?:\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
 
 function setup(app, cb){
-    console.log("TEST ", typeof app, urlRegex.test(app));
     function cbProxy(err, server) {
         cb(err, 'http://localhost:' + webserver.address().port)
     }

--- a/src/webserver-handling.js
+++ b/src/webserver-handling.js
@@ -30,7 +30,10 @@ function setup(app, cb){
 }
 
 function teardown (cb) {
-    webserver && webserver.close(cb);
+    if (webserver) {
+        return webserver.close(cb);
+    }
+    cb();
 }
 
 module.exports = {

--- a/src/webserver-handling.js
+++ b/src/webserver-handling.js
@@ -30,7 +30,7 @@ function setup(app, cb){
 }
 
 function teardown (cb) {
-    webserver.close(cb);
+    webserver && webserver.close(cb);
 }
 
 module.exports = {

--- a/src/webserver-handling.js
+++ b/src/webserver-handling.js
@@ -1,8 +1,9 @@
 var http = require('http');
 var webserver;
-var urlPattern = new RegExp('(http|https)://[\w-]+(\.[\w-]+)+([\w.,@?^=%&amp;:/~+#-]*[\w@?^=%&amp;/~+#-])?')
+var urlRegex = /https?:\/\/(\w+:{0,1}\w*@)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%@!\-\/]))?/;
 
 function setup(app, cb){
+    console.log("TEST ", typeof app, urlRegex.test(app));
     function cbProxy(err, server) {
         cb(err, 'http://localhost:' + webserver.address().port)
     }
@@ -10,7 +11,7 @@ function setup(app, cb){
         throw new Error('No webserver defined');
     }
     // Caller has started the app externally. Just use the url they gave you.
-    else if (typeof app === 'string' && urlPattern.test(app)) {
+    else if (typeof app === 'string' && urlRegex.test(app)) {
         cb(null, app)
     }
     //Express and similar compatible apps have the 'listen' method defined

--- a/src/webserver-handling.js
+++ b/src/webserver-handling.js
@@ -1,29 +1,31 @@
 var http = require('http');
 var webserver;
+var urlPattern = new RegExp('(http|https)://[\w-]+(\.[\w-]+)+([\w.,@?^=%&amp;:/~+#-]*[\w@?^=%&amp;/~+#-])?')
 
 function setup(app, cb){
+    function cbProxy(err, server) {
+        cb(err, 'http://localhost:' + webserver.address().port)
+    }
     if(!app){
-        throw {
-            message: "No webserver defined",
-            got: app
-        };
+        throw new Error('No webserver defined');
+    }
+    // Caller has started the app externally. Just use the url they gave you.
+    else if (typeof app === 'string' && urlPattern.test(app)) {
+        cb(null, app)
     }
     //Express and similar compatible apps have the 'listen' method defined
     else if (!!app.listen){
-        webserver = app.listen(3000, cb);
+        webserver = app.listen(0, cbProxy);
     }
     //it might be koa or else unknown
     else if(app.hasOwnProperty('env')){
             // It appears to be koa:
             // https://github.com/wilmoore/node-supertest-koa-agent
             webserver = http.createServer(app.callback());
-            webserver.listen(3000, cb);
+            webserver.listen(0, cbProxy);
     }
     else {
-        throw {
-            message: "Unable to start app, couldn't identify or start up app",
-            app: app
-        };
+        throw new Error('Unable to start app, couldn\'t identify or start up app');
     }
 }
 


### PR DESCRIPTION
These changes were mainly to allow me to run against a provider that i spin up myself (rather than passing an Express/Koa/Restify 'app').

Also done a bit of refactoring here and there and may have introduced breaking changes particularly around the throwing of Errors rather than weird looking objects. The test suite doesn't exactly fill me with confidence :(

@ychua I'm hopeful that this will somehow end up in npmjs (or the just the seek npm repo). It looks like it's been left by the wayside for some time so I'm not holding my breath.